### PR TITLE
Fix 404 relative link to correct absolute URL.

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -37,7 +37,7 @@ Each ZodError has an `issues` property that is an array of `ZodIssues`. Each iss
 
 `ZodIssue` is _not_ a class. It is a [discriminated union](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions).
 
-The link above is the best way to learn about the concept. Discriminated unions are an ideal way to represent a data structures that may be one of many possible variants. You can see all the possible variants defined [here](./src/ZodError.ts). They are also described in the table below if you prefer.
+The link above is the best way to learn about the concept. Discriminated unions are an ideal way to represent a data structures that may be one of many possible variants. You can see all the possible variants defined in the [ZodError.ts source](https://github.com/colinhacks/zod/blob/master/src/ZodError.ts). They are also described in the table below if you prefer.
 
 _Every_ ZodIssue has these fields:
 


### PR DESCRIPTION
The existing link for ZodError.ts was a relative link which tried to resolve to:
https://zod.js.org/docs/guides/error-handling/src/ZodError.ts

Which only returns a 404 error.

The actual URL it wanted to point to is here:
https://github.com/colinhacks/zod/blob/master/src/ZodError.ts

So I updated the link to be an absolute URL. 

Additionally a modified the text slightly in accordance with accessibility best practices in which link test should be self explanatory. "ZodError.ts source" is more descriptive than "here".